### PR TITLE
Only import needed files

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,6 +1,6 @@
 <script context="module" lang="ts">
   import client from "../lib/apollo";
-  import { gql } from "@apollo/client";
+  import { gql } from "@apollo/client/core";
 
   const EVERYTHING = gql`
     {


### PR DESCRIPTION
I changed it so it imports "@apollo/client/core" instead of "@apollo/client" **to avoid unnecessary react dependency.**

This stops it from complaining about react and makes it faster when running "yarn run dev".

Got the fix here: https://spectrum.chat/apollo/apollo-client/do-i-have-to-install-react-to-use-apollo-client~252348df-030e-422b-8eb2-49c57787d2ee